### PR TITLE
Add audio install hint to device table fallback

### DIFF
--- a/adsum/core/audio/devices.py
+++ b/adsum/core/audio/devices.py
@@ -52,7 +52,10 @@ def list_input_devices() -> List[DeviceInfo]:
 def format_device_table() -> str:
     devices = list_input_devices()
     if not devices:
-        return "No input devices detected. Ensure sounddevice is installed and audio hardware is accessible."
+        return (
+            "No input devices detected. Install optional audio support with "
+            "`pip install adsum[audio]` and ensure audio hardware is accessible."
+        )
 
     header = f"{'ID':>3} | {'Name':<40} | {'In':>2} | {'Rate':>7} | Host API | Loopback"
     lines = [header, "-" * len(header)]

--- a/tests/test_audio_devices.py
+++ b/tests/test_audio_devices.py
@@ -1,0 +1,16 @@
+"""Tests for audio device utilities."""
+
+from __future__ import annotations
+
+from adsum.core.audio import devices
+
+
+def test_format_device_table_fallback_contains_install_hint(monkeypatch) -> None:
+    """When no devices are found the fallback message should include install hint."""
+
+    monkeypatch.setattr(devices, "list_input_devices", lambda: [])
+
+    message = devices.format_device_table()
+
+    assert message.startswith("No input devices detected.")
+    assert "pip install adsum[audio]" in message


### PR DESCRIPTION
## Summary
- update the audio device table fallback message to mention `pip install adsum[audio]`
- add a unit test ensuring the fallback output includes the installation hint

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d12432601c8329917ffcdfbbda510f