### PR TITLE
Add streaming transcription support with incremental callbacks

### DIFF
--- a/adsum/data/models.py
+++ b/adsum/data/models.py
@@ -10,8 +10,8 @@ from pydantic import BaseModel, Field
 
 
 class TranscriptSegment(BaseModel):
-    start: float
-    end: float
+    start: Optional[float] = None
+    end: Optional[float] = None
     text: str
 
 

--- a/adsum/services/transcription/base.py
+++ b/adsum/services/transcription/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import abc
 from pathlib import Path
+from typing import Callable, Optional
 
 from ...data.models import RecordingSession, TranscriptResult
 
@@ -14,6 +15,16 @@ class TranscriptionService(abc.ABC):
     @abc.abstractmethod
     def transcribe(self, session: RecordingSession, audio_path: Path) -> TranscriptResult:
         raise NotImplementedError
+
+    def transcribe_stream(
+        self,
+        session: RecordingSession,
+        audio_path: Path,
+        on_update: Optional[Callable[[TranscriptResult], None]] = None,
+    ) -> TranscriptResult:
+        """Transcribe audio while optionally emitting incremental updates."""
+
+        return self.transcribe(session, audio_path)
 
 
 __all__ = ["TranscriptionService"]

--- a/adsum/services/transcription/dummy.py
+++ b/adsum/services/transcription/dummy.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Callable, Optional
 
-from ...data.models import RecordingSession, TranscriptResult
+from ...data.models import RecordingSession, TranscriptResult, TranscriptSegment
 from .base import TranscriptionService
 
 
@@ -21,7 +22,30 @@ class DummyTranscriptionService(TranscriptionService):
             session_id=session.id,
             channel=self.channel_name,
             text=text,
+            segments=[TranscriptSegment(text=text)],
         )
+
+    def transcribe_stream(
+        self,
+        session: RecordingSession,
+        audio_path: Path,
+        on_update: Optional[Callable[[TranscriptResult], None]] = None,
+    ) -> TranscriptResult:
+        result = self.transcribe(session, audio_path)
+        if on_update is not None:
+            preview_text = result.text.split(". ")[0].strip()
+            if preview_text:
+                preview = TranscriptResult(
+                    session_id=session.id,
+                    channel=self.channel_name,
+                    text=preview_text,
+                    segments=[TranscriptSegment(text=preview_text)],
+                )
+                try:
+                    on_update(preview)
+                except Exception:  # pragma: no cover - defensive guard for callbacks
+                    pass
+        return result
 
 
 __all__ = ["DummyTranscriptionService"]

--- a/adsum/services/transcription/openai_client.py
+++ b/adsum/services/transcription/openai_client.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Dict, List, Optional
 
 from ...config import get_settings
 from ...data.models import RecordingSession, TranscriptResult, TranscriptSegment
@@ -43,6 +44,139 @@ class OpenAITranscriptionService(TranscriptionService):
             segments=segments,
             raw_response=response,
         )
+
+    def transcribe_stream(
+        self,
+        session: RecordingSession,
+        audio_path: Path,
+        on_update: Optional[Callable[[TranscriptResult], None]] = None,
+    ) -> TranscriptResult:
+        if on_update is None:
+            return self.transcribe(session, audio_path)
+
+        streaming = getattr(self.client.audio.transcriptions, "with_streaming_response", None)
+        if streaming is None:
+            LOGGER.info("OpenAI client does not support streaming responses; using batch transcription")
+            return self.transcribe(session, audio_path)
+
+        channel = audio_path.stem
+        text_parts: List[str] = []
+        incremental_segments: List[str] = []
+        last_payload: Optional[TranscriptResult] = None
+
+        def emit_partial() -> None:
+            nonlocal last_payload
+            text = "".join(text_parts).strip()
+            segments = [
+                TranscriptSegment(text=segment.strip())
+                for segment in incremental_segments
+                if segment.strip()
+            ]
+            if not text and not segments:
+                return
+            last_payload = TranscriptResult(
+                session_id=session.id,
+                channel=channel,
+                text=text,
+                segments=segments,
+            )
+            try:
+                on_update(last_payload)
+            except Exception:  # pragma: no cover - callbacks should not break pipeline
+                LOGGER.exception("Transcript update callback raised an exception")
+
+        LOGGER.info("Requesting OpenAI streaming transcription for %s", audio_path)
+        parsed: object | None = None
+        try:
+            with open(audio_path, "rb") as audio_file:
+                with streaming.create(
+                    model=self.model,
+                    file=audio_file,
+                    response_format="verbose_json",
+                    stream=True,
+                ) as response:
+                    for line in response.iter_lines():
+                        if not line or line.startswith(":"):
+                            continue
+                        if line.strip().upper() == "DATA: [DONE]":
+                            break
+                        if not line.startswith("data:"):
+                            continue
+                        payload = line[len("data:") :].strip()
+                        if not payload or payload == "[DONE]":
+                            continue
+                        try:
+                            data: Dict[str, object] = json.loads(payload)
+                        except json.JSONDecodeError:
+                            LOGGER.debug("Failed to decode streaming payload: %s", payload)
+                            continue
+                        event_type = str(data.get("type", ""))
+                        if event_type == "transcript.text.delta":
+                            delta = str(data.get("delta", ""))
+                            if delta:
+                                text_parts.append(delta)
+                                incremental_segments.append(delta)
+                                emit_partial()
+                        elif event_type == "transcript.text.done":
+                            text = str(data.get("text", ""))
+                            if text:
+                                text_parts.append(text)
+                                incremental_segments.append(text)
+                                emit_partial()
+                        elif event_type == "response.completed":
+                            break
+
+                    parsed = response.parse()
+        except Exception as exc:  # pragma: no cover - requires network failures
+            LOGGER.exception("Streaming transcription failed; falling back to batch mode: %s", exc)
+            return self.transcribe(session, audio_path)
+
+        segments: List[TranscriptSegment] = []
+        text = "".join(text_parts).strip()
+        raw_response = None
+        try:
+            from openai.types.audio.transcription_verbose import TranscriptionVerbose
+
+            if isinstance(parsed, TranscriptionVerbose):
+                raw_response = parsed.model_dump()
+                text = parsed.text or text
+                for segment in parsed.segments or []:
+                    segments.append(
+                        TranscriptSegment(
+                            start=getattr(segment, "start", None),
+                            end=getattr(segment, "end", None),
+                            text=(getattr(segment, "text", "") or "").strip(),
+                        )
+                    )
+            elif hasattr(parsed, "model_dump"):
+                raw_response = parsed.model_dump()
+                text = raw_response.get("text", text)
+                for segment in raw_response.get("segments", []) or []:
+                    segments.append(
+                        TranscriptSegment(
+                            start=segment.get("start"),
+                            end=segment.get("end"),
+                            text=(segment.get("text") or "").strip(),
+                        )
+                    )
+        except Exception:  # pragma: no cover - best effort parsing
+            LOGGER.debug("Failed to parse streaming response payload", exc_info=True)
+
+        final_result = TranscriptResult(
+            session_id=session.id,
+            channel=channel,
+            text=text,
+            segments=segments,
+            raw_response=raw_response,
+        )
+
+        if last_payload is None or last_payload.model_dump() != final_result.model_dump():
+            try:
+                on_update(final_result)
+            except Exception:  # pragma: no cover - callbacks should not break pipeline
+                LOGGER.exception("Transcript update callback raised an exception")
+
+        return final_result
 
 
 __all__ = ["OpenAITranscriptionService"]

--- a/adsum/ui/window.py
+++ b/adsum/ui/window.py
@@ -667,6 +667,7 @@ class RecordingWindowUI:
                 notes=notes,
                 control=control,
                 transcript_callback=self._on_transcript_result,
+                transcript_update_callback=self._on_transcript_result,
             )
             self._pending_outcome = outcome
         except Exception as exc:  # pragma: no cover - runtime behaviour


### PR DESCRIPTION
## Summary
- add a streaming transcription entry point to the orchestrator so clients can receive incremental updates while persisting the final transcript
- extend the OpenAI transcription client with best-effort SSE parsing, fallback handling, and incremental callbacks; update the dummy backend accordingly
- relax transcript segment timing requirements, plumb streaming updates through the window UI, and add coverage for the new callback behavior

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d12c6389e0832997b831470c3f6ec1