### PR TITLE
Resample audio inputs before mixing

### DIFF
--- a/adsum/utils/audio.py
+++ b/adsum/utils/audio.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import wave
 from pathlib import Path
-from typing import Iterable, List, Optional, Tuple
+from typing import Iterable, List, Tuple
 
 import numpy as np
 
@@ -41,26 +41,38 @@ def ensure_mono(data: np.ndarray) -> np.ndarray:
     return data.mean(axis=1, keepdims=True)
 
 
+def _resample_array(array: np.ndarray, sr: int, target_sr: int) -> np.ndarray:
+    if sr == target_sr:
+        return array
+    mono = array[:, 0]
+    length = mono.shape[0]
+    if length == 0:
+        return mono.reshape(0, 1)
+    target_length = max(int(round(length * target_sr / sr)), 1)
+    if target_length == 1:
+        return np.full((1, 1), mono[0], dtype=array.dtype)
+    original_positions = np.linspace(0, length - 1, num=length)
+    target_positions = np.linspace(0, length - 1, num=target_length)
+    resampled = np.interp(target_positions, original_positions, mono).astype(array.dtype, copy=False)
+    return resampled.reshape(-1, 1)
+
+
 def mix_audio_files(paths: Iterable[Path], output_path: Path) -> Path:
-    data_arrays: List[np.ndarray] = []
-    sample_rate: Optional[int] = None
-    min_length: Optional[int] = None
+    data_entries: List[Tuple[np.ndarray, int]] = []
     for path in paths:
         array, sr = read_wave(path)
         array = ensure_mono(array)
-        if sample_rate is None:
-            sample_rate = sr
-        elif sr != sample_rate:
-            raise ValueError("Sample rates must match for mixing")
-        if min_length is None or array.shape[0] < min_length:
-            min_length = array.shape[0]
-        data_arrays.append(array)
-    if not data_arrays:
+        data_entries.append((array, sr))
+    if not data_entries:
         raise ValueError("No audio files supplied for mixing")
-    assert min_length is not None and sample_rate is not None
-    stacked = np.stack([arr[:min_length, 0] for arr in data_arrays], axis=0)
+    target_sample_rate = max(sr for _, sr in data_entries)
+    resampled_arrays: List[np.ndarray] = []
+    for array, sr in data_entries:
+        resampled_arrays.append(_resample_array(array, sr, target_sample_rate))
+    min_length = min(array.shape[0] for array in resampled_arrays)
+    stacked = np.stack([arr[:min_length, 0] for arr in resampled_arrays], axis=0)
     mixed = stacked.mean(axis=0)
-    write_wave(output_path, mixed.reshape(-1, 1), sample_rate)
+    write_wave(output_path, mixed.reshape(-1, 1), target_sample_rate)
     return output_path
 
 

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -23,3 +23,33 @@ def test_mix_audio_files(tmp_path: Path) -> None:
     assert sr == sample_rate
     assert mixed.shape[0] == sample_rate
     assert mixed.shape[1] == 1
+
+
+def test_mix_audio_files_resample(tmp_path: Path) -> None:
+    sample_rate_a = 16000
+    sample_rate_b = 22050
+    t_a = np.linspace(0, 1, sample_rate_a, endpoint=False)
+    t_b = np.linspace(0, 1, sample_rate_b, endpoint=False)
+    tone_a = np.sin(2 * np.pi * 440 * t_a).astype(np.float32)
+    tone_b = np.sin(2 * np.pi * 880 * t_b).astype(np.float32)
+
+    path_a = tmp_path / "a.wav"
+    path_b = tmp_path / "b.wav"
+    write_wave(path_a, tone_a, sample_rate_a)
+    write_wave(path_b, tone_b, sample_rate_b)
+
+    mix_path = tmp_path / "mix.wav"
+    mix_audio_files([path_a, path_b], mix_path)
+
+    mixed, sr = read_wave(mix_path)
+    assert sr == max(sample_rate_a, sample_rate_b)
+    assert mixed.shape == (sr, 1)
+
+    t = np.linspace(0, 1, sr, endpoint=False)
+    tone_440 = np.sin(2 * np.pi * 440 * t)
+    tone_880 = np.sin(2 * np.pi * 880 * t)
+    correlation_440 = np.abs(np.dot(mixed[:, 0], tone_440) / sr)
+    correlation_880 = np.abs(np.dot(mixed[:, 0], tone_880) / sr)
+
+    assert correlation_440 > 0.1
+    assert correlation_880 > 0.1


### PR DESCRIPTION
## Summary
- resample mismatched audio inputs to a shared rate before mixing
- recompute alignment using resampled arrays while keeping existing normalisation
- add a regression test that mixes tones recorded at different sample rates

## Testing
- PYTHONPATH=. pytest tests/test_audio_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d17c6bfa348329882474af35ee7dc5