### PR TITLE
Handle mixdown failure fallback

### DIFF
--- a/adsum/core/pipeline/orchestrator.py
+++ b/adsum/core/pipeline/orchestrator.py
@@ -180,13 +180,16 @@ class RecordingOrchestrator:
 
         mix_path: Optional[Path] = None
         if request.mix_down and len(capture_paths) >= 1:
-            mix_path = dirs["processed"] / "mix.wav"
+            candidate_mix_path = dirs["processed"] / "mix.wav"
             try:
-                mix_audio_files(list(capture_paths.values()), mix_path)
-                session.mix_path = mix_path
-                self.store.update_mix_path(session.id, mix_path)
+                mix_audio_files(list(capture_paths.values()), candidate_mix_path)
             except Exception as exc:  # pragma: no cover - exercised only with problematic files
                 LOGGER.exception("Failed to mix down audio: %s", exc)
+                mix_path = None
+            else:
+                mix_path = candidate_mix_path
+                session.mix_path = mix_path
+                self.store.update_mix_path(session.id, mix_path)
 
         transcripts: Dict[str, TranscriptResult] = {}
         if transcription is not None and (mix_path or capture_paths):


### PR DESCRIPTION
## Summary
- ensure mixdown failures leave the session mix path unset and transcription falls back to raw captures
- add a regression test covering mixdown failure fallback to the system channel

## Testing
- PYTHONPATH=. pytest tests/test_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_68d180481df4832989b0bc0d8425dac3