### PR TITLE
Update sounddevice requirement for WASAPI loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Install the package in editable mode with the audio extras:
 pip install -e .[audio]
 ```
 
+> **Windows users:** WASAPI loopback capture requires `sounddevice` version 0.4.6 or later, which is included in the `audio` extras.
+
 Listing audio devices:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-audio = ["sounddevice>=0.4"]
+audio = ["sounddevice>=0.4.6"]
 
 [project.scripts]
 adsum = "adsum.cli:app"


### PR DESCRIPTION
## Summary
- require sounddevice 0.4.6 or newer in the audio extra to ensure WASAPI loopback support
- document the Windows dependency in the Getting started section of the README

## Testing
- `pip install -e .[audio]`
- `adsum devices`


------
https://chatgpt.com/codex/tasks/task_e_68d1a35229b0832997967ac770dbed21