### PR TITLE
Add FFmpeg audio backend for Bluetooth capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ adsum ui --mic-device 2 --system-device 5 --transcription-backend openai --notes
 
 The UI launches from the terminal and lets you start, pause, resume, and stop recordings without additional CLI commands. Each channel is written to `recordings/<session-id>/raw`, a combined track is optionally rendered, and transcription/note generation can be triggered from the interface. Results are stored in `adsum.db`.
 
+### Capturing Bluetooth audio with FFmpeg
+
+ADsum now uses FFmpeg as the default capture engine so Bluetooth sources exposed by the operating system can be recorded reliably. When prompted for the microphone or system device provide an FFmpeg-style input specification using the pattern `<format>:<target>?option=value&...`. Examples:
+
+```
+# PulseAudio / PipeWire loopback for a Bluetooth headset
+pulse:bluez_source.AA_BB_CC_DD_EE_FF.monitor?sample_rate=48000&channels=2
+
+# Windows DirectShow capture from a Bluetooth microphone
+dshow:audio=Bluetooth Headset?sample_rate=48000&channels=1
+
+# macOS AVFoundation input index 1
+avfoundation:1?channels=1
+```
+
+Additional FFmpeg flags can be added via query parameters. For instance `args=-thread_queue_size 2048` (parsed with shell-style quoting) or `opt_timeout=5` (expanded to `-timeout 5`). If you prefer the previous PortAudio backend set `ADSUM_AUDIO_BACKEND=sounddevice`.
+
 Use the "Configure environment" menu entry to inspect or update any `ADSUM_` variables directly from the UI. Changes are persisted to your `.env` file for future sessions.
 
 ## Configuration
@@ -63,6 +80,8 @@ Environment variables customise behaviour via `pydantic` settings (prefix `ADSUM
 - `ADSUM_SAMPLE_RATE`: Sample rate used for capture (default `16000`).
 - `ADSUM_CHANNELS`: Number of channels per capture stream (default `1`).
 - `ADSUM_CHUNK_SECONDS`: Preferred chunk duration when streaming (default `1.0`).
+- `ADSUM_AUDIO_BACKEND`: Audio engine to use (`ffmpeg` by default, `sounddevice` for the legacy backend).
+- `ADSUM_FFMPEG_BINARY`: Override FFmpeg executable path when the binary is not available on PATH.
 - `ADSUM_DEFAULT_MIC_DEVICE`: Preferred microphone device identifier remembered between sessions.
 - `ADSUM_DEFAULT_SYSTEM_DEVICE`: Preferred system audio device identifier remembered between sessions.
 - `ADSUM_OPENAI_TRANSCRIPTION_MODEL`: Model used for OpenAI transcription.

--- a/adsum/config.py
+++ b/adsum/config.py
@@ -19,6 +19,8 @@ class Settings(BaseSettings):
     sample_rate: int = 16_000
     channels: int = 1
     chunk_seconds: float = 1.0
+    audio_backend: str = "ffmpeg"
+    ffmpeg_binary: str = "ffmpeg"
     openai_transcription_model: str = "gpt-4o-mini-transcribe"
     openai_notes_model: str = "gpt-4o-mini"
     openai_api_key: Optional[str] = None

--- a/adsum/core/audio/factory.py
+++ b/adsum/core/audio/factory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
+from ...config import get_settings
 from .base import AudioCapture, CaptureError, CaptureInfo
 
 
@@ -20,6 +21,8 @@ class CaptureRequest:
     device: Optional[str]
     sample_rate: int
     channels: int
+    backend: Optional[str] = None
+    chunk_seconds: Optional[float] = None
 
 
 def _parse_device(device: Optional[str]) -> Optional[int | str]:
@@ -36,28 +39,80 @@ def _parse_device(device: Optional[str]) -> Optional[int | str]:
 def create_capture(request: CaptureRequest) -> Optional[AudioCapture]:
     """Create an :class:`AudioCapture` implementation for the given request."""
 
-    device = _parse_device(request.device)
-    if device is None:
+    settings = get_settings()
+    backend = (request.backend or settings.audio_backend or "").strip().lower()
+
+    if backend in {"", "none"}:
         return None
 
-    try:
-        from .sounddevice_backend import SoundDeviceCapture
-    except ImportError as exc:  # pragma: no cover - depends on optional dependency
-        raise CaptureConfigurationError(
-            "sounddevice dependency is required for audio capture"
-        ) from exc
+    if backend == "ffmpeg":
+        if not request.device:
+            raise CaptureConfigurationError("FFmpeg backend requires a device string")
 
-    capture_info = CaptureInfo(
-        name=request.channel,
-        sample_rate=request.sample_rate,
-        channels=request.channels,
-        device=str(request.device),
-    )
+        try:
+            from .ffmpeg_backend import FFmpegCapture, parse_ffmpeg_device
+        except ImportError as exc:  # pragma: no cover - defensive
+            raise CaptureConfigurationError("FFmpeg backend is unavailable") from exc
 
-    try:
-        return SoundDeviceCapture(info=capture_info, device=device)
-    except CaptureError as exc:
-        raise CaptureConfigurationError(str(exc)) from exc
+        capture_info = CaptureInfo(
+            name=request.channel,
+            sample_rate=request.sample_rate,
+            channels=request.channels,
+            device=str(request.device),
+        )
+
+        try:
+            spec = parse_ffmpeg_device(
+                request.device,
+                default_sample_rate=capture_info.sample_rate,
+                default_channels=capture_info.channels,
+            )
+        except CaptureError as exc:
+            raise CaptureConfigurationError(str(exc)) from exc
+
+        chunk_seconds = request.chunk_seconds
+        if chunk_seconds is None:
+            chunk_seconds = settings.chunk_seconds
+
+        chunk_frames = max(int(spec.sample_rate * max(chunk_seconds, 0.001)), 1)
+        if spec.chunk_frames is not None:
+            chunk_frames = max(spec.chunk_frames, 1)
+
+        try:
+            return FFmpegCapture(
+                info=capture_info,
+                spec=spec,
+                binary=settings.ffmpeg_binary,
+                chunk_frames=chunk_frames,
+            )
+        except CaptureError as exc:
+            raise CaptureConfigurationError(str(exc)) from exc
+
+    if backend == "sounddevice":
+        device = _parse_device(request.device)
+        if device is None:
+            return None
+
+        try:
+            from .sounddevice_backend import SoundDeviceCapture
+        except ImportError as exc:  # pragma: no cover - depends on optional dependency
+            raise CaptureConfigurationError(
+                "sounddevice dependency is required for audio capture"
+            ) from exc
+
+        capture_info = CaptureInfo(
+            name=request.channel,
+            sample_rate=request.sample_rate,
+            channels=request.channels,
+            device=str(request.device),
+        )
+
+        try:
+            return SoundDeviceCapture(info=capture_info, device=device)
+        except CaptureError as exc:
+            raise CaptureConfigurationError(str(exc)) from exc
+
+    raise CaptureConfigurationError(f"Unknown audio backend: {backend}")
 
 
 __all__ = ["CaptureConfigurationError", "CaptureRequest", "create_capture"]

--- a/adsum/core/audio/ffmpeg_backend.py
+++ b/adsum/core/audio/ffmpeg_backend.py
@@ -1,0 +1,390 @@
+"""Audio capture implementation powered by the FFmpeg command line tool."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import queue
+import shlex
+import shutil
+import subprocess
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+from urllib.parse import parse_qsl, urlsplit
+
+import numpy as np
+
+from .base import AudioCapture, CaptureError, CaptureInfo
+from ...logging import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+_OUTPUT_CODECS = {
+    "f32le": "pcm_f32le",
+    "s16le": "pcm_s16le",
+    "s32le": "pcm_s32le",
+}
+
+_DTYPE_FOR_FORMAT = {
+    "f32le": np.float32,
+    "s16le": np.int16,
+    "s32le": np.int32,
+}
+
+_FORMAT_SCALE = {
+    "f32le": 1.0,
+    "s16le": 32768.0,
+    "s32le": 2147483648.0,
+}
+
+
+@dataclass
+class FFmpegDeviceSpec:
+    """Parsed representation of an FFmpeg capture target."""
+
+    input_format: str
+    input_target: str
+    args_before_input: List[str]
+    args_after_input: List[str]
+    sample_rate: int
+    channels: int
+    sample_format: str
+    chunk_frames: Optional[int]
+
+
+def parse_ffmpeg_device(
+    device: str,
+    *,
+    default_sample_rate: int,
+    default_channels: int,
+) -> FFmpegDeviceSpec:
+    """Return a :class:`FFmpegDeviceSpec` parsed from the user supplied string."""
+
+    if not device:
+        raise CaptureError("FFmpeg backend requires a device specification")
+
+    split = urlsplit(device)
+    if not split.scheme:
+        raise CaptureError(
+            "FFmpeg device specification must start with an input format, "
+            "for example 'pulse:bluez_source.XX' or 'dshow:audio=Device'",
+        )
+
+    input_format = split.scheme
+    input_target = (split.netloc + split.path).strip()
+
+    if not input_target:
+        raise CaptureError("FFmpeg device specification must include a device identifier")
+
+    args_before: List[str] = []
+    args_after: List[str] = []
+    sample_rate = int(default_sample_rate)
+    channels = int(default_channels)
+    sample_format = "f32le"
+    chunk_frames: Optional[int] = None
+    pending_chunk_ms: Optional[float] = None
+
+    for key, value in parse_qsl(split.query, keep_blank_values=True):
+        if key == "sample_rate" and value:
+            try:
+                sample_rate = int(value)
+            except ValueError as exc:
+                raise CaptureError(f"Invalid FFmpeg sample_rate: {value}") from exc
+        elif key == "channels" and value:
+            try:
+                channels = int(value)
+            except ValueError as exc:
+                raise CaptureError(f"Invalid FFmpeg channels: {value}") from exc
+        elif key == "sample_fmt" and value:
+            sample_format = value.lower()
+        elif key == "chunk_frames" and value:
+            try:
+                chunk_frames = max(int(value), 1)
+            except ValueError as exc:
+                raise CaptureError(f"Invalid FFmpeg chunk_frames: {value}") from exc
+        elif key == "chunk_ms" and value:
+            try:
+                pending_chunk_ms = max(float(value), 0.0)
+            except ValueError as exc:
+                raise CaptureError(f"Invalid FFmpeg chunk_ms: {value}") from exc
+        elif key == "args" and value:
+            args_before.extend(shlex.split(value))
+        elif key == "out_args" and value:
+            args_after.extend(shlex.split(value))
+        elif key.startswith("opt_"):
+            option = "-" + key[4:].replace("_", "-")
+            if value:
+                args_before.extend([option, value])
+            else:
+                args_before.append(option)
+        elif key.startswith("flag_"):
+            option = "-" + key[5:].replace("_", "-")
+            args_before.append(option)
+        elif key.startswith("out_opt_"):
+            option = "-" + key[8:].replace("_", "-")
+            if value:
+                args_after.extend([option, value])
+            else:
+                args_after.append(option)
+        elif key.startswith("out_flag_"):
+            option = "-" + key[9:].replace("_", "-")
+            args_after.append(option)
+        elif not key:
+            continue
+        else:
+            raise CaptureError(f"Unknown FFmpeg device option: {key}")
+
+    if sample_rate <= 0:
+        raise CaptureError("FFmpeg sample_rate must be a positive integer")
+    if channels <= 0:
+        raise CaptureError("FFmpeg channels must be a positive integer")
+
+    if pending_chunk_ms is not None and chunk_frames is None:
+        chunk_frames = max(int(sample_rate * (pending_chunk_ms / 1000.0)), 1)
+
+    sample_format = sample_format.lower()
+    if sample_format not in _OUTPUT_CODECS:
+        raise CaptureError(
+            "FFmpeg output format must be one of: "
+            + ", ".join(sorted(_OUTPUT_CODECS.keys()))
+        )
+
+    return FFmpegDeviceSpec(
+        input_format=input_format,
+        input_target=input_target,
+        args_before_input=args_before,
+        args_after_input=args_after,
+        sample_rate=sample_rate,
+        channels=channels,
+        sample_format=sample_format,
+        chunk_frames=chunk_frames,
+    )
+
+
+class FFmpegCapture(AudioCapture):
+    """Capture stream that reads audio samples from an FFmpeg subprocess."""
+
+    def __init__(
+        self,
+        info: CaptureInfo,
+        *,
+        spec: FFmpegDeviceSpec,
+        binary: str = "ffmpeg",
+        chunk_frames: Optional[int] = None,
+    ) -> None:
+        self.info = info
+        self._spec = spec
+        self._binary = binary
+        self.info.sample_rate = spec.sample_rate
+        self.info.channels = spec.channels
+        self._chunk_frames = chunk_frames or spec.chunk_frames or max(self.info.sample_rate // 10, 1)
+        self._raw_dtype = _DTYPE_FOR_FORMAT[spec.sample_format]
+        self._scale = _FORMAT_SCALE[spec.sample_format]
+        self._queue: "queue.Queue[np.ndarray]" = queue.Queue()
+        self._process: Optional[subprocess.Popen] = None
+        self._reader_thread: Optional[threading.Thread] = None
+        self._stderr_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._buffer = bytearray()
+
+    def start(self) -> None:
+        if self._process is not None:
+            return
+
+        executable = _resolve_binary(self._binary)
+        if executable is None:
+            raise CaptureError(f"FFmpeg binary '{self._binary}' was not found on PATH")
+
+        command = self._build_command(executable)
+        LOGGER.info("Starting FFmpeg capture for %s using %s", self.info.name, executable)
+
+        try:
+            process = subprocess.Popen(  # noqa: S603 - required to spawn ffmpeg
+                command,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                bufsize=0,
+            )
+        except FileNotFoundError as exc:
+            raise CaptureError(f"Failed to launch FFmpeg binary '{executable}'") from exc
+
+        assert process.stdout is not None  # narrow type for mypy
+        assert process.stderr is not None
+
+        self._process = process
+        self._stop_event.clear()
+
+        self._reader_thread = threading.Thread(target=self._reader_loop, daemon=True)
+        self._reader_thread.start()
+
+        self._stderr_thread = threading.Thread(
+            target=self._stderr_loop,
+            args=(process.stderr,),
+            daemon=True,
+        )
+        self._stderr_thread.start()
+
+    def stop(self) -> None:
+        process = self._process
+        if process is None:
+            return
+
+        LOGGER.info("Stopping FFmpeg capture for %s", self.info.name)
+        self._stop_event.set()
+
+        with contextlib.suppress(Exception):
+            process.terminate()
+            process.wait(timeout=1)
+    
+        if process.poll() is None:
+            with contextlib.suppress(Exception):
+                process.kill()
+
+    def close(self) -> None:
+        process = self._process
+        self._process = None
+        self._stop_event.set()
+
+        if process is not None:
+            with contextlib.suppress(Exception):
+                process.stdout and process.stdout.close()
+            with contextlib.suppress(Exception):
+                process.stderr and process.stderr.close()
+
+        if self._reader_thread is not None:
+            self._reader_thread.join(timeout=1)
+            self._reader_thread = None
+
+        if self._stderr_thread is not None:
+            self._stderr_thread.join(timeout=1)
+            self._stderr_thread = None
+
+        self._drain_queue()
+        self._buffer.clear()
+
+    def read(self, timeout: Optional[float] = None) -> Optional[np.ndarray]:
+        try:
+            if timeout is None or timeout <= 0:
+                return self._queue.get_nowait()
+            return self._queue.get(timeout=timeout)
+        except queue.Empty:
+            return None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _build_command(self, executable: str) -> List[str]:
+        command: List[str] = [
+            executable,
+            "-hide_banner",
+            "-loglevel",
+            "warning",
+            "-nostats",
+        ]
+        command.extend(self._spec.args_before_input)
+        command.extend(["-f", self._spec.input_format])
+        command.extend(["-i", self._spec.input_target])
+        command.extend(self._spec.args_after_input)
+        command.extend(["-vn", "-sn", "-dn"])
+        command.extend(["-ac", str(self.info.channels)])
+        command.extend(["-ar", str(self.info.sample_rate)])
+        command.extend(["-acodec", _OUTPUT_CODECS[self._spec.sample_format]])
+        command.extend(["-f", self._spec.sample_format, "pipe:1"])
+        return command
+
+    def _reader_loop(self) -> None:  # pragma: no cover - exercised in integration tests
+        assert self._process is not None
+        stdout = self._process.stdout
+        assert stdout is not None
+        chunk_bytes = self._chunk_frames * self.info.channels * np.dtype(self._raw_dtype).itemsize
+
+        while not self._stop_event.is_set():
+            data = stdout.read(chunk_bytes)
+            if not data:
+                break
+            self._buffer.extend(data)
+            self._flush_ready_chunks(chunk_bytes)
+
+        self._flush_ready_chunks(chunk_bytes, drain_all=True)
+
+        if self._process and self._process.poll() not in (0, None):
+            LOGGER.warning(
+                "FFmpeg exited with code %s while capturing %s",
+                self._process.returncode,
+                self.info.name,
+            )
+
+    def _stderr_loop(self, pipe: io.BufferedReader) -> None:  # pragma: no cover - runtime logging
+        try:
+            for line in iter(pipe.readline, b""):
+                text = line.decode(errors="ignore").strip()
+                if text:
+                    LOGGER.debug("ffmpeg[%s]: %s", self.info.name, text)
+        finally:
+            with contextlib.suppress(Exception):
+                pipe.close()
+
+    def _flush_ready_chunks(self, chunk_bytes: int, drain_all: bool = False) -> None:
+        frame_size = self.info.channels * np.dtype(self._raw_dtype).itemsize
+        if frame_size <= 0:
+            return
+
+        while len(self._buffer) >= frame_size:
+            if len(self._buffer) < chunk_bytes and not drain_all:
+                break
+
+            take = min(len(self._buffer), chunk_bytes if len(self._buffer) >= chunk_bytes else len(self._buffer))
+            take = (take // frame_size) * frame_size
+            if take <= 0:
+                break
+
+            raw = bytes(self._buffer[:take])
+            del self._buffer[:take]
+            if not raw:
+                continue
+
+            array = np.frombuffer(raw, dtype=self._raw_dtype)
+            if array.size == 0:
+                continue
+
+            frames = array.reshape((-1, self.info.channels))
+            if self._scale != 1.0:
+                frames = frames.astype(np.float32) / float(self._scale)
+            else:
+                frames = frames.astype(np.float32, copy=False)
+            self._queue.put(frames)
+
+        if drain_all:
+            self._buffer.clear()
+
+    def _drain_queue(self) -> None:
+        while not self._queue.empty():
+            try:
+                self._queue.get_nowait()
+            except queue.Empty:
+                break
+
+
+def _resolve_binary(binary: str) -> Optional[str]:
+    """Return the absolute path to the requested FFmpeg binary if available."""
+
+    if not binary:
+        binary = "ffmpeg"
+
+    found = shutil.which(binary)
+    if found:
+        return found
+
+    candidate = Path(binary)
+    if candidate.exists():
+        return str(candidate)
+
+    return None
+
+
+__all__ = ["FFmpegCapture", "FFmpegDeviceSpec", "parse_ffmpeg_device"]
+

--- a/adsum/ui/console.py
+++ b/adsum/ui/console.py
@@ -161,6 +161,8 @@ class RecordingConsoleUI:
                         device=device,
                         sample_rate=self.sample_rate,
                         channels=self.channels,
+                        backend=self._settings.audio_backend,
+                        chunk_seconds=self._settings.chunk_seconds,
                     )
                 )
             except CaptureConfigurationError as exc:

--- a/adsum/ui/window.py
+++ b/adsum/ui/window.py
@@ -334,6 +334,8 @@ class RecordingWindowUI:
                             device=device,
                             sample_rate=self.sample_rate,
                             channels=self.channels,
+                            backend=self._settings.audio_backend,
+                            chunk_seconds=self._settings.chunk_seconds,
                         )
                     )
                 except CaptureConfigurationError as exc:

--- a/tests/test_audio_devices.py
+++ b/tests/test_audio_devices.py
@@ -6,6 +6,7 @@ import sys
 from dataclasses import dataclass
 
 from adsum.core.audio import devices
+from adsum import config
 from adsum.core.audio.base import CaptureInfo
 
 
@@ -52,6 +53,11 @@ class _FakeSoundDeviceModule:
 def test_format_device_table_fallback_contains_install_hint(monkeypatch) -> None:
     """When no devices are found the fallback message should include install hint."""
 
+    monkeypatch.setattr(
+        devices,
+        "get_settings",
+        lambda: config.Settings(audio_backend="sounddevice"),
+    )
     monkeypatch.setattr(devices, "list_input_devices", lambda: [])
 
     message = devices.format_device_table()

--- a/tests/test_ffmpeg_backend.py
+++ b/tests/test_ffmpeg_backend.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pytest
+
+import adsum.core.audio.ffmpeg_backend as ffmpeg_backend
+from adsum.core.audio.base import CaptureInfo
+from adsum.core.audio.ffmpeg_backend import (
+    FFmpegCapture,
+    parse_ffmpeg_device,
+    CaptureError,
+)
+
+
+def test_parse_ffmpeg_device_accepts_overrides() -> None:
+    spec = parse_ffmpeg_device(
+        "pulse:bluez_source.test?sample_rate=48000&channels=2&sample_fmt=s16le&args=-thread_queue_size 1024",
+        default_sample_rate=16000,
+        default_channels=1,
+    )
+
+    assert spec.input_format == "pulse"
+    assert spec.input_target == "bluez_source.test"
+    assert spec.sample_rate == 48000
+    assert spec.channels == 2
+    assert spec.sample_format == "s16le"
+    assert spec.args_before_input == ["-thread_queue_size", "1024"]
+
+
+def test_parse_ffmpeg_device_rejects_unknown_option() -> None:
+    with pytest.raises(CaptureError):
+        parse_ffmpeg_device(
+            "pulse:device?unexpected=1",
+            default_sample_rate=16000,
+            default_channels=1,
+        )
+
+
+class _FakeProcess:
+    def __init__(self, stdout_bytes: bytes) -> None:
+        self.stdout = io.BufferedReader(io.BytesIO(stdout_bytes))
+        self.stderr = io.BufferedReader(io.BytesIO(b""))
+        self._returncode = 0
+
+    def terminate(self) -> None:  # pragma: no cover - no behaviour change in tests
+        pass
+
+    def wait(self, timeout: float | None = None) -> int:  # pragma: no cover - trivial
+        return self._returncode
+
+    def poll(self) -> int:  # pragma: no cover - trivial
+        return self._returncode
+
+    def kill(self) -> None:  # pragma: no cover - trivial
+        self._returncode = -9
+
+
+def test_ffmpeg_capture_stream(monkeypatch) -> None:
+    spec = parse_ffmpeg_device(
+        "pulse:device?sample_rate=48000&channels=2&sample_fmt=s16le",
+        default_sample_rate=16000,
+        default_channels=1,
+    )
+    info = CaptureInfo(name="microphone", sample_rate=16000, channels=1)
+    capture = FFmpegCapture(info, spec=spec, binary="ffmpeg", chunk_frames=2)
+
+    sample = np.array([[0, 32767], [16384, -32768]], dtype=np.int16).tobytes()
+    fake_process = _FakeProcess(sample)
+    recorded: dict = {}
+
+    monkeypatch.setattr(ffmpeg_backend, "_resolve_binary", lambda binary: "/usr/bin/ffmpeg")
+
+    def fake_popen(cmd, stdin, stdout, stderr, bufsize):
+        recorded["cmd"] = cmd
+        return fake_process
+
+    monkeypatch.setattr(ffmpeg_backend.subprocess, "Popen", fake_popen)
+
+    capture.start()
+    chunk = capture.read(timeout=1.0)
+    capture.stop()
+    capture.close()
+
+    assert recorded["cmd"][0] == "/usr/bin/ffmpeg"
+    assert chunk is not None
+    assert chunk.shape == (2, 2)
+    assert np.isclose(chunk[0, 1], 1.0, atol=1e-4)
+    assert np.isclose(chunk[1, 0], 0.5, atol=1e-4)


### PR DESCRIPTION
## Summary
- introduce an FFmpeg-based audio capture backend and expose configuration knobs for backend and binary selection
- wire the new backend through the CLI/UIs, update device discovery messaging, and document FFmpeg-based Bluetooth capture workflows
- expand the test suite with FFmpeg capture coverage and refresh existing tests for the backend selection changes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2361233b083299f6269b118c291f5