### PR TITLE
Ensure notes upsert behavior for sessions

### DIFF
--- a/adsum/data/storage.py
+++ b/adsum/data/storage.py
@@ -61,6 +61,12 @@ class SessionStore:
                 )
                 """
             )
+            conn.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_notes_session_id
+                ON notes(session_id)
+                """
+            )
             conn.commit()
 
     def save_session(self, session: RecordingSession) -> None:
@@ -114,8 +120,12 @@ class SessionStore:
         with self._connect() as conn:
             conn.execute(
                 """
-                INSERT OR REPLACE INTO notes (session_id, title, summary, action_items)
+                INSERT INTO notes (session_id, title, summary, action_items)
                 VALUES (?, ?, ?, ?)
+                ON CONFLICT(session_id) DO UPDATE SET
+                    title=excluded.title,
+                    summary=excluded.summary,
+                    action_items=excluded.action_items
                 """,
                 (
                     notes.session_id,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,40 @@
+import sqlite3
+
+from adsum.data.models import NoteDocument
+from adsum.data.storage import SessionStore
+
+
+def test_save_notes_upserts_on_session_id(tmp_path):
+    db_path = tmp_path / "adsum.db"
+    store = SessionStore(db_path)
+    store.initialize()
+
+    original = NoteDocument(
+        session_id="session-123",
+        title="Initial",
+        summary="First summary",
+        action_items=["a"],
+    )
+    updated = NoteDocument(
+        session_id="session-123",
+        title="Updated",
+        summary="Revised summary",
+        action_items=["b"],
+    )
+
+    store.save_notes(original)
+    store.save_notes(updated)
+
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM notes WHERE session_id = ?", ("session-123",)
+        ).fetchone()[0]
+
+    assert count == 1
+
+    fetched = store.fetch_notes("session-123")
+    assert fetched is not None
+    assert fetched.title == updated.title
+    assert fetched.summary == updated.summary
+    assert fetched.action_items == updated.action_items
+


### PR DESCRIPTION
## Summary
- add a unique index on notes.session_id so each session has at most one notes row
- update SessionStore.save_notes to upsert on session_id conflicts
- add a regression test confirming repeated saves overwrite existing notes instead of inserting duplicates

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d255a2bc248329b52a10f431d3cc6e