### PR TITLE
Fallback to sounddevice when ffmpeg missing

### DIFF
--- a/tests/test_audio_factory.py
+++ b/tests/test_audio_factory.py
@@ -59,3 +59,47 @@ def test_sounddevice_capture_respects_disable_keywords(monkeypatch) -> None:
     )
 
     assert create_capture(request) is None
+
+
+def test_ffmpeg_backend_falls_back_to_sounddevice(monkeypatch) -> None:
+    """When FFmpeg is unavailable, the factory should switch to sounddevice."""
+
+    import adsum.core.audio.factory as factory_module
+    import adsum.core.audio.ffmpeg_backend as ffmpeg_backend
+
+    class DummySettings:
+        audio_backend = "ffmpeg"
+        ffmpeg_binary = "ffmpeg"
+        chunk_seconds = 0.5
+
+    monkeypatch.setattr(factory_module, "get_settings", lambda: DummySettings())
+
+    monkeypatch.setattr(ffmpeg_backend, "_resolve_binary", lambda binary: None)
+
+    captured: dict[str, object] = {}
+
+    class DummySoundDeviceCapture:
+        def __init__(self, info, device) -> None:  # pragma: no cover - simple initializer
+            captured["info"] = info
+            captured["device"] = device
+
+    fake_module = types.SimpleNamespace(SoundDeviceCapture=DummySoundDeviceCapture)
+    monkeypatch.setitem(
+        sys.modules,
+        "adsum.core.audio.sounddevice_backend",
+        fake_module,
+    )
+
+    request = CaptureRequest(
+        channel="microphone",
+        device="pulse:default",
+        sample_rate=16_000,
+        channels=1,
+        backend="ffmpeg",
+    )
+
+    capture = create_capture(request)
+
+    assert isinstance(capture, DummySoundDeviceCapture)
+    assert captured["device"] is None
+    assert captured["info"].device == "default"


### PR DESCRIPTION
## Summary
- add a reusable helper that builds SoundDevice captures and reuse it for multiple paths
- detect missing FFmpeg binaries during capture creation and transparently fall back to the sounddevice backend without warning spam
- cover the new behaviour with a factory test that exercises the automatic fallback

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d2754d96dc832989609408dc4ad349