### PR TITLE
Auto-probe audio devices before recording

### DIFF
--- a/tests/test_audio_devices.py
+++ b/tests/test_audio_devices.py
@@ -66,6 +66,32 @@ def test_format_device_table_fallback_contains_install_hint(monkeypatch) -> None
     assert "pip install adsum[audio]" in message
 
 
+def test_format_device_table_accepts_custom_device_list(monkeypatch) -> None:
+    """Providing an explicit device list should bypass automatic discovery."""
+
+    monkeypatch.setattr(
+        devices,
+        "get_settings",
+        lambda: config.Settings(audio_backend="sounddevice"),
+    )
+
+    custom_devices = [
+        devices.DeviceInfo(
+            id=7,
+            name="Custom Microphone",
+            max_input_channels=2,
+            default_samplerate=48_000.0,
+            hostapi="CoreAudio",
+            is_loopback=False,
+        )
+    ]
+
+    table = devices.format_device_table(custom_devices)
+
+    assert "Custom Microphone" in table
+    assert "  7 |" in table
+
+
 def test_wasapi_loopback_fallback_without_keyword(monkeypatch) -> None:
     """Older sounddevice builds should enable WASAPI loopback via fallback logic."""
 


### PR DESCRIPTION
## Summary
- automatically probe detected audio devices when starting a session and restrict the selection list to those that succeeded
- surface the probe results inside the recording configuration dialog and log skipped devices for visibility
- allow providing explicit device lists to `format_device_table` and cover the new behaviour with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d27cb9cef083298024fa91df7351c0