### PR TITLE
Handle FFmpeg backend in device auto-detection

### DIFF
--- a/adsum/ui/window.py
+++ b/adsum/ui/window.py
@@ -1065,6 +1065,15 @@ class RecordingWindowUI:
         return stripped
 
     def _auto_detect_working_devices(self) -> Tuple[List[DeviceInfo], str]:
+        backend = (self._settings.audio_backend or "").strip().lower()
+
+        if backend == "ffmpeg":
+            message = format_device_table()
+            self._info(
+                "FFmpeg audio backend active; skipping automatic device probing."
+            )
+            return [], message
+
         devices = list_input_devices()
 
         if not devices:

--- a/tests/test_ui_window.py
+++ b/tests/test_ui_window.py
@@ -1,0 +1,35 @@
+"""Tests for the window UI helpers."""
+
+from __future__ import annotations
+
+from collections import deque
+
+import pytest
+
+from adsum.ui import window as window_module
+
+
+def test_auto_detect_working_devices_skips_probe_for_ffmpeg(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When FFmpeg backend is active, probing should be skipped."""
+
+    sentinel_message = "use ffmpeg instructions"
+
+    def _fail_list_input_devices():
+        raise AssertionError("sounddevice enumeration should not run for FFmpeg")
+
+    def _capture_format_table(devices=None):  # type: ignore[override]
+        assert devices is None
+        return sentinel_message
+
+    monkeypatch.setattr(window_module, "list_input_devices", _fail_list_input_devices)
+    monkeypatch.setattr(window_module, "format_device_table", _capture_format_table)
+
+    ui = object.__new__(window_module.RecordingWindowUI)
+    ui._settings = type("_S", (), {"audio_backend": "ffmpeg"})()
+    ui._messages = deque()
+    ui._log_widget = None
+
+    working, report = window_module.RecordingWindowUI._auto_detect_working_devices(ui)
+
+    assert working == []
+    assert report == sentinel_message


### PR DESCRIPTION
## Summary
- skip sounddevice probing when the FFmpeg backend is active and surface the device instructions instead
- add regression coverage for the FFmpeg auto-detection branch

## Testing
- PYTHONPATH=. pytest tests/test_ui_window.py

------
https://chatgpt.com/codex/tasks/task_e_68d29e7347348329aec7e3d1e5c80897