### PR TITLE
Add FFmpeg device enumeration support and tests

### DIFF
--- a/adsum/core/audio/devices.py
+++ b/adsum/core/audio/devices.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import os
+import re
+import subprocess
+import sys
 from dataclasses import dataclass
-from typing import Iterable, List, Optional
+from typing import Callable, Iterable, List, Optional, Sequence
 
 from ...config import get_settings
 from ...logging import get_logger
+from .ffmpeg_backend import FFmpegBinaryNotFoundError, ensure_ffmpeg_available
 from .sounddevice_backend import wasapi_loopback_capable
 
 LOGGER = get_logger(__name__)
@@ -20,6 +25,32 @@ class DeviceInfo:
     default_samplerate: float
     hostapi: str
     is_loopback: bool
+
+
+@dataclass
+class FFmpegDevice:
+    """Structured information about an FFmpeg-reported capture source."""
+
+    index: int
+    name: str
+    input_format: str
+    channels: Optional[int] = None
+    sample_rate: Optional[int] = None
+    details: Optional[str] = None
+
+
+class FFmpegDeviceEnumerationError(RuntimeError):
+    """Raised when FFmpeg cannot enumerate available devices."""
+
+
+def _detect_ffmpeg_platform() -> str:
+    if os.name == "nt":
+        return "windows"
+    if sys.platform == "darwin":
+        return "darwin"
+    if sys.platform.startswith("linux"):
+        return "linux"
+    return "unknown"
 
 
 def list_input_devices() -> List[DeviceInfo]:
@@ -77,7 +108,28 @@ def format_device_table(devices: Optional[Iterable[DeviceInfo]] = None) -> str:
     backend = (settings.audio_backend or "").lower()
 
     if backend == "ffmpeg" and devices is None:
-        return _format_ffmpeg_instructions(settings.ffmpeg_binary)
+        try:
+            ffmpeg_devices = list_ffmpeg_devices()
+        except FFmpegBinaryNotFoundError as exc:
+            LOGGER.warning("FFmpeg binary missing while listing devices: %s", exc)
+            return format_ffmpeg_error_message(
+                settings.ffmpeg_binary,
+                f"Unable to launch FFmpeg for device enumeration: {exc}",
+            )
+        except FFmpegDeviceEnumerationError as exc:
+            LOGGER.warning("FFmpeg device enumeration failed: %s", exc)
+            return format_ffmpeg_error_message(
+                settings.ffmpeg_binary,
+                f"Unable to enumerate FFmpeg audio devices: {exc}",
+            )
+
+        if not ffmpeg_devices:
+            return format_ffmpeg_error_message(
+                settings.ffmpeg_binary,
+                "No FFmpeg audio input devices were reported.",
+            )
+
+        return _format_ffmpeg_device_table(ffmpeg_devices)
 
     if devices is None:
         device_list = list_input_devices()
@@ -98,6 +150,70 @@ def format_device_table(devices: Optional[Iterable[DeviceInfo]] = None) -> str:
             f"{int(device.default_samplerate):>7} | {device.hostapi:<8} | {('yes' if device.is_loopback else 'no'):>8}"
         )
     return "\n".join(lines)
+
+
+def list_ffmpeg_devices() -> List[FFmpegDevice]:
+    """Return audio capture devices reported by the configured FFmpeg binary."""
+
+    settings = get_settings()
+    binary = settings.ffmpeg_binary or "ffmpeg"
+    executable = ensure_ffmpeg_available(binary) or binary
+
+    platform = _detect_ffmpeg_platform()
+    command: Sequence[str]
+    parser: Callable[[str], List[FFmpegDevice]]
+    if platform == "windows":
+        command = [
+            executable,
+            "-hide_banner",
+            "-list_devices",
+            "true",
+            "-f",
+            "dshow",
+            "-i",
+            "dummy",
+        ]
+        parser = _parse_ffmpeg_dshow_devices
+    elif platform == "darwin":
+        command = [
+            executable,
+            "-hide_banner",
+            "-list_devices",
+            "true",
+            "-f",
+            "avfoundation",
+            "-i",
+            "",
+        ]
+        parser = _parse_ffmpeg_avfoundation_devices
+    elif platform == "linux":
+        command = [
+            executable,
+            "-hide_banner",
+            "-sources",
+            "pulse",
+        ]
+        parser = _parse_ffmpeg_pulse_devices
+    else:
+        raise FFmpegDeviceEnumerationError(
+            "FFmpeg device enumeration is not supported on this platform."
+        )
+
+    try:
+        completed = subprocess.run(  # noqa: S603,S607 - trusted binary determined by settings
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - exercised via FFmpegBinaryNotFoundError
+        raise FFmpegBinaryNotFoundError(binary) from exc
+    except OSError as exc:
+        raise FFmpegDeviceEnumerationError(str(exc)) from exc
+
+    output = "\n".join(filter(None, [completed.stdout, completed.stderr]))
+    devices = parser(output)
+    return devices
 
 
 def _format_ffmpeg_instructions(binary: str) -> str:
@@ -122,5 +238,204 @@ def _format_ffmpeg_instructions(binary: str) -> str:
     return "\n".join(message)
 
 
-__all__ = ["DeviceInfo", "list_input_devices", "format_device_table"]
+def format_ffmpeg_error_message(binary: str, message: str) -> str:
+    base = _format_ffmpeg_instructions(binary)
+    return f"{base}\n\n{message}"
+
+
+def _format_ffmpeg_device_table(devices: Sequence[FFmpegDevice]) -> str:
+    header = f"{'ID':>3} | {'Name':<40} | {'In':>2} | {'Rate':>7} | Host API | Loopback"
+    lines = [header, "-" * len(header)]
+    for device in devices:
+        display_name = device.name
+        if device.details and device.details not in display_name:
+            combined = f"{display_name} ({device.details})"
+            display_name = combined
+        channels = str(device.channels) if device.channels is not None else "--"
+        sample_rate = (
+            str(int(device.sample_rate))
+            if device.sample_rate is not None and device.sample_rate > 0
+            else "--"
+        )
+        lines.append(
+            "{} | {} | {} | {} | {} | {}".format(
+                f"{device.index:>3}",
+                f"{display_name:<40.40}",
+                f"{channels:>2}",
+                f"{sample_rate:>7}",
+                f"{device.input_format:<8.8}",
+                f"{'n/a':>8}",
+            )
+        )
+    return "\n".join(lines)
+
+
+def _ffmpeg_payload(line: str) -> str:
+    if "]" in line:
+        _, payload = line.split("]", 1)
+        return payload.strip()
+    return line.strip()
+
+
+def _parse_ffmpeg_dshow_devices(output: str) -> List[FFmpegDevice]:
+    devices: List[FFmpegDevice] = []
+    in_audio_section = False
+    for line in output.splitlines():
+        payload = _ffmpeg_payload(line)
+        if not payload:
+            continue
+        lowered = payload.lower()
+        if "directshow audio devices" in lowered:
+            in_audio_section = True
+            continue
+        if "directshow video devices" in lowered:
+            in_audio_section = False
+            continue
+        if not in_audio_section:
+            continue
+        alt_match = re.search(r"alternative name\s*:?-?\s*\"([^\"]+)\"", payload, re.IGNORECASE)
+        if alt_match and devices:
+            devices[-1].details = alt_match.group(1)
+            continue
+        name_match = re.search(r'"([^"]+)"', payload)
+        if name_match:
+            name = name_match.group(1)
+            device = FFmpegDevice(
+                index=len(devices),
+                name=name,
+                input_format="dshow",
+            )
+            devices.append(device)
+    return devices
+
+
+def _parse_ffmpeg_avfoundation_devices(output: str) -> List[FFmpegDevice]:
+    devices: List[FFmpegDevice] = []
+    in_audio_section = False
+    for line in output.splitlines():
+        payload = _ffmpeg_payload(line)
+        if not payload:
+            continue
+        lowered = payload.lower()
+        if "avfoundation audio devices" in lowered:
+            in_audio_section = True
+            continue
+        if "avfoundation video devices" in lowered:
+            in_audio_section = False
+            continue
+        if not in_audio_section:
+            continue
+        match = re.match(r"\[(\d+)\]\s*(.+)", payload)
+        if not match:
+            continue
+        index = int(match.group(1))
+        name = match.group(2).strip()
+        devices.append(
+            FFmpegDevice(
+                index=index,
+                name=name,
+                input_format="avfoundation",
+            )
+        )
+    devices.sort(key=lambda item: item.index)
+    return devices
+
+
+def _parse_ffmpeg_pulse_devices(output: str) -> List[FFmpegDevice]:
+    devices: List[FFmpegDevice] = []
+    in_sources = False
+    current: Optional[FFmpegDevice] = None
+    current_raw_name: Optional[str] = None
+
+    def _finalize_current() -> None:
+        nonlocal current, current_raw_name
+        if current is None:
+            return
+        if current.name:
+            if current_raw_name and current_raw_name != current.name:
+                current.details = current_raw_name
+        elif current_raw_name:
+            current.name = current_raw_name
+        devices.append(current)
+        current = None
+        current_raw_name = None
+
+    for line in output.splitlines():
+        payload = _ffmpeg_payload(line)
+        if not payload:
+            continue
+        lowered = payload.lower()
+        if lowered.startswith("sources"):
+            in_sources = True
+            _finalize_current()
+            continue
+        if lowered.startswith("sinks"):
+            in_sources = False
+            _finalize_current()
+            break
+        if not in_sources:
+            continue
+
+        source_match = re.match(r"source\s*#(\d+)", payload, re.IGNORECASE)
+        index_match = re.match(r"(\d+):\s*(.+)", payload)
+        if source_match:
+            _finalize_current()
+            current = FFmpegDevice(index=int(source_match.group(1)), name="", input_format="pulse")
+            current_raw_name = None
+            continue
+        if index_match:
+            _finalize_current()
+            current = FFmpegDevice(
+                index=int(index_match.group(1)),
+                name=index_match.group(2).strip(),
+                input_format="pulse",
+            )
+            current_raw_name = current.name or None
+            continue
+        if current is None:
+            continue
+
+        if lowered.startswith("name:"):
+            value = payload.split(":", 1)[1].strip()
+            current_raw_name = value or current_raw_name
+            if not current.name:
+                current.name = value
+            continue
+        if lowered.startswith("description:"):
+            value = payload.split(":", 1)[1].strip()
+            if value:
+                current.name = value
+            continue
+        if lowered.startswith("sample spec:"):
+            spec = payload.split(":", 1)[1].strip()
+            channel_match = re.search(r"(\d+)ch", spec)
+            if channel_match:
+                current.channels = int(channel_match.group(1))
+            rate_match = re.search(r"(\d+)hz", spec, re.IGNORECASE)
+            if rate_match:
+                try:
+                    current.sample_rate = int(rate_match.group(1))
+                except ValueError:
+                    current.sample_rate = None
+            continue
+        if lowered.startswith("channels:") and current.channels is None:
+            try:
+                current.channels = int(payload.split(":", 1)[1].strip().split()[0])
+            except (ValueError, IndexError):
+                current.channels = None
+
+    _finalize_current()
+    devices.sort(key=lambda item: item.index)
+    return devices
+
+
+__all__ = [
+    "DeviceInfo",
+    "FFmpegDevice",
+    "FFmpegDeviceEnumerationError",
+    "list_input_devices",
+    "list_ffmpeg_devices",
+    "format_device_table",
+    "format_ffmpeg_error_message",
+]
 

--- a/tests/test_audio_devices.py
+++ b/tests/test_audio_devices.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import sys
+import textwrap
 from dataclasses import dataclass
+from types import SimpleNamespace
 
 from adsum.core.audio import devices
 from adsum import config
@@ -137,3 +139,171 @@ def test_wasapi_loopback_fallback_without_keyword(monkeypatch) -> None:
     ]
 
     assert devices.list_input_devices() == []
+
+
+def _mock_ffmpeg_run(output: str) -> SimpleNamespace:
+    return SimpleNamespace(stdout="", stderr=output, returncode=1)
+
+
+def test_list_ffmpeg_devices_parses_dshow_output(monkeypatch) -> None:
+    """Windows FFmpeg listings should return structured DirectShow devices."""
+
+    listing = textwrap.dedent(
+        """
+        [dshow @ 0x123] DirectShow video devices (some comment)
+        [dshow @ 0x123]  "Integrated Camera"
+        [dshow @ 0x123] DirectShow audio devices
+        [dshow @ 0x123]  "Microphone (Realtek(R) Audio)" (audio)
+        [dshow @ 0x123]     Alternative name "@device_cm_{123ABC}"
+        [dshow @ 0x123]  "Stereo Mix (Realtek(R) Audio)" (audio)
+        """
+    ).strip()
+
+    monkeypatch.setattr(devices, "ensure_ffmpeg_available", lambda binary: binary)
+    monkeypatch.setattr(devices, "get_settings", lambda: config.Settings(ffmpeg_binary="ffmpeg"))
+    monkeypatch.setattr(devices, "_detect_ffmpeg_platform", lambda: "windows")
+    monkeypatch.setattr(devices.subprocess, "run", lambda *_, **__: _mock_ffmpeg_run(listing))
+
+    results = devices.list_ffmpeg_devices()
+
+    assert [device.name for device in results] == [
+        "Microphone (Realtek(R) Audio)",
+        "Stereo Mix (Realtek(R) Audio)",
+    ]
+    assert results[0].details == "@device_cm_{123ABC}"
+    assert all(device.input_format == "dshow" for device in results)
+
+
+def test_list_ffmpeg_devices_parses_avfoundation_output(monkeypatch) -> None:
+    """macOS FFmpeg listings should surface AVFoundation audio devices."""
+
+    listing = textwrap.dedent(
+        """
+        [AVFoundation input device @ 0x9] AVFoundation video devices:
+        [AVFoundation input device @ 0x9] [0] FaceTime HD Camera
+        [AVFoundation input device @ 0x9] AVFoundation audio devices:
+        [AVFoundation input device @ 0x9] [1] Built-in Microphone
+        [AVFoundation input device @ 0x9] [3] External USB Audio
+        """
+    ).strip()
+
+    monkeypatch.setattr(devices, "ensure_ffmpeg_available", lambda binary: binary)
+    monkeypatch.setattr(devices, "get_settings", lambda: config.Settings(ffmpeg_binary="ffmpeg"))
+    monkeypatch.setattr(devices, "_detect_ffmpeg_platform", lambda: "darwin")
+    monkeypatch.setattr(devices.subprocess, "run", lambda *_, **__: _mock_ffmpeg_run(listing))
+
+    results = devices.list_ffmpeg_devices()
+
+    assert [device.index for device in results] == [1, 3]
+    assert [device.name for device in results] == [
+        "Built-in Microphone",
+        "External USB Audio",
+    ]
+    assert all(device.input_format == "avfoundation" for device in results)
+
+
+def test_list_ffmpeg_devices_parses_pulse_output(monkeypatch) -> None:
+    """Linux FFmpeg listings should parse PulseAudio sources with metadata."""
+
+    listing = textwrap.dedent(
+        """
+        [pulse @ 0x7f] Sources:
+        [pulse @ 0x7f] Source #0
+        [pulse @ 0x7f]   Name: alsa_input.pci-0000_00_1b.0.analog-stereo
+        [pulse @ 0x7f]   Description: Built-in Audio Analog Stereo
+        [pulse @ 0x7f]   Sample Spec: s16le 2ch 44100Hz
+        [pulse @ 0x7f] Source #2
+        [pulse @ 0x7f]   Name: bluez_input.11_22_33_44_55_66.a2dp-source
+        [pulse @ 0x7f]   Sample Spec: s16le 1ch 48000Hz
+        [pulse @ 0x7f] Sinks:
+        [pulse @ 0x7f] Sink #0
+        """
+    ).strip()
+
+    monkeypatch.setattr(devices, "ensure_ffmpeg_available", lambda binary: binary)
+    monkeypatch.setattr(devices, "get_settings", lambda: config.Settings(ffmpeg_binary="ffmpeg"))
+    monkeypatch.setattr(devices, "_detect_ffmpeg_platform", lambda: "linux")
+    monkeypatch.setattr(devices.subprocess, "run", lambda *_, **__: _mock_ffmpeg_run(listing))
+
+    results = devices.list_ffmpeg_devices()
+
+    assert [device.index for device in results] == [0, 2]
+    assert results[0].name == "Built-in Audio Analog Stereo"
+    assert results[0].details == "alsa_input.pci-0000_00_1b.0.analog-stereo"
+    assert results[0].channels == 2
+    assert results[0].sample_rate == 44100
+    assert results[1].name == "bluez_input.11_22_33_44_55_66.a2dp-source"
+    assert results[1].channels == 1
+    assert results[1].sample_rate == 48000
+
+
+def test_format_device_table_ffmpeg_formats_results(monkeypatch) -> None:
+    """format_device_table should render FFmpeg listings in a tabular layout."""
+
+    monkeypatch.setattr(
+        devices,
+        "get_settings",
+        lambda: config.Settings(audio_backend="ffmpeg", ffmpeg_binary="ffmpeg"),
+    )
+    monkeypatch.setattr(
+        devices,
+        "list_ffmpeg_devices",
+        lambda: [
+            devices.FFmpegDevice(
+                index=0,
+                name="Built-in Microphone",
+                input_format="avfoundation",
+            ),
+            devices.FFmpegDevice(
+                index=1,
+                name="USB Interface",
+                input_format="pulse",
+                channels=2,
+                sample_rate=48_000,
+                details="alsa_input.usb-123",
+            ),
+        ],
+    )
+
+    table = devices.format_device_table()
+
+    assert "Built-in Microphone" in table
+    assert "USB Interface" in table
+    assert "48000" in table
+    assert "pulse" in table
+
+
+def test_format_device_table_ffmpeg_handles_errors(monkeypatch) -> None:
+    """Failures during FFmpeg enumeration should include diagnostic output."""
+
+    monkeypatch.setattr(
+        devices,
+        "get_settings",
+        lambda: config.Settings(audio_backend="ffmpeg", ffmpeg_binary="ffmpeg"),
+    )
+    monkeypatch.setattr(
+        devices,
+        "list_ffmpeg_devices",
+        lambda: (_ for _ in ()).throw(devices.FFmpegDeviceEnumerationError("boom")),
+    )
+
+    message = devices.format_device_table()
+
+    assert "FFmpeg backend is active" in message
+    assert "Unable to enumerate FFmpeg audio devices" in message
+    assert "boom" in message
+
+
+def test_format_device_table_ffmpeg_empty_listing(monkeypatch) -> None:
+    """Empty FFmpeg results should surface an explicit notice."""
+
+    monkeypatch.setattr(
+        devices,
+        "get_settings",
+        lambda: config.Settings(audio_backend="ffmpeg", ffmpeg_binary="ffmpeg"),
+    )
+    monkeypatch.setattr(devices, "list_ffmpeg_devices", lambda: [])
+
+    message = devices.format_device_table()
+
+    assert "No FFmpeg audio input devices were reported." in message


### PR DESCRIPTION
## Summary
- add an FFmpeg-backed device discovery helper that parses dshow, avfoundation, and pulse listings and feeds format_device_table
- route the console and window UIs through the new table rendering helper so FFmpeg errors surface helpful instructions
- add unit tests that exercise the FFmpeg parsers, table output, and error handling

## Testing
- PYTHONPATH=. pytest tests/test_audio_devices.py
- PYTHONPATH=. pytest tests/test_ui_window.py

------
https://chatgpt.com/codex/tasks/task_e_68d2a50c27008329948014cc99c9d84c