### PR TITLE
Fix ffmpeg flag initialization in recording dialog

### DIFF
--- a/adsum/ui/window.py
+++ b/adsum/ui/window.py
@@ -1230,6 +1230,10 @@ class RecordingWindowUI:
         else:
             devices = list(available_devices)
 
+        ffmpeg_backend_active = (
+            (self._settings.audio_backend or "").strip().lower() == "ffmpeg"
+        )
+
         ffmpeg_devices: List[FFmpegDevice] = []
         if ffmpeg_backend_active:
             ffmpeg_devices = self._load_ffmpeg_devices_for_options()
@@ -1249,9 +1253,6 @@ class RecordingWindowUI:
         main = ttk.Frame(window, padding=(20, 16))
         main.grid(row=0, column=0, sticky="nsew")
         main.columnconfigure(1, weight=1)
-        ffmpeg_backend_active = (
-            (self._settings.audio_backend or "").strip().lower() == "ffmpeg"
-        )
         preview_text: Optional[ScrolledText] = None
 
         preview_row = 6 if ffmpeg_backend_active else None


### PR DESCRIPTION
## Summary
- compute the ffmpeg backend flag before it is first read when building the recording configuration dialog
- reuse the computed value later in the layout setup to avoid UnboundLocalError when the ffmpeg backend is disabled

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'adsum')*

------
https://chatgpt.com/codex/tasks/task_e_68d2b153dd688329931685a90b6c311b