### PR TITLE
Warn when capture channels are silent

### DIFF
--- a/adsum/ui/console.py
+++ b/adsum/ui/console.py
@@ -503,6 +503,18 @@ class RecordingConsoleUI:
                 self._last_outcome = self._pending_outcome
                 summary = f"Session saved at {self._pending_outcome.session.id}"
                 self._info(summary)
+                if self._pending_outcome.channel_metrics:
+                    for metrics in self._pending_outcome.channel_metrics.values():
+                        if getattr(metrics, "is_silent", False):
+                            device_label = metrics.device or "unknown device"
+                            audio_path = self._pending_outcome.session.audio_paths.get(
+                                metrics.channel
+                            )
+                            path_hint = f" (file: {audio_path})" if audio_path else ""
+                            self._warning(
+                                "No audio was captured from "
+                                f"{metrics.channel} ({device_label}){path_hint}."
+                            )
                 if self._pending_outcome.transcripts:
                     counts = ", ".join(
                         f"{ch}: {len(result.text.split())} words"
@@ -646,6 +658,9 @@ class RecordingConsoleUI:
 
     def _info(self, message: str) -> None:
         self._messages.append(f"[info] {message}")
+
+    def _warning(self, message: str) -> None:
+        self._messages.append(f"[warning] {message}")
 
     def _error(self, message: str) -> None:
         self._messages.append(f"[error] {message}")

--- a/adsum/ui/window.py
+++ b/adsum/ui/window.py
@@ -1774,6 +1774,19 @@ class RecordingWindowUI:
                 self._last_outcome = self._pending_outcome
                 summary = f"Session saved at {self._pending_outcome.session.id}"
                 self._info(summary)
+                if self._pending_outcome.channel_metrics:
+                    for metrics in self._pending_outcome.channel_metrics.values():
+                        if getattr(metrics, "is_silent", False):
+                            device_label = metrics.device or "unknown device"
+                            audio_path = self._pending_outcome.session.audio_paths.get(
+                                metrics.channel
+                            )
+                            path_hint = f" ({audio_path})" if audio_path else ""
+                            self._warning(
+                                "No audio was captured from "
+                                f"{metrics.channel} ({device_label}){path_hint}. "
+                                "Please check the device before recording again."
+                            )
                 if self._pending_outcome.transcripts:
                     counts = ", ".join(
                         f"{ch}: {len(result.text.split())} words"
@@ -1935,6 +1948,12 @@ class RecordingWindowUI:
     def _info(self, message: str) -> None:
         self._messages.append(f"[info] {message}")
         self._append_log(f"[info] {message}")
+
+    def _warning(self, message: str) -> None:
+        self._messages.append(f"[warning] {message}")
+        self._append_log(f"[warning] {message}")
+        if messagebox is not None and self._root is not None:
+            messagebox.showwarning("ADsum", message, parent=self._root)
 
     def _error(self, message: str) -> None:
         self._messages.append(f"[error] {message}")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import numpy as np
 
+import adsum.core.pipeline.orchestrator as orchestrator_module
 from adsum.core.audio.base import AudioCapture, CaptureInfo
 from adsum.core.pipeline.orchestrator import (
     RecordingControl,
@@ -151,6 +152,81 @@ def test_orchestrator_uses_raw_targets_when_mix_fails(tmp_path: Path, monkeypatc
     recorded_stems = {path.stem for path in transcription.paths}
     assert recorded_stems == {"microphone", "system"}
     assert set(outcome.transcripts.keys()) == recorded_stems
+
+
+def test_orchestrator_reports_silent_channels(tmp_path: Path) -> None:
+    db_path = tmp_path / "adsum.db"
+    store = SessionStore(db_path)
+    orchestrator = RecordingOrchestrator(base_dir=tmp_path / "recordings", store=store)
+
+    sample_rate = 16000
+    chunk = np.zeros((sample_rate // 10, 1), dtype=np.float32)
+    captures = {
+        "microphone": FakeCapture(
+            CaptureInfo(name="microphone", sample_rate=sample_rate, channels=1),
+            [chunk],
+        ),
+        "system": FakeCapture(
+            CaptureInfo(name="system", sample_rate=sample_rate, channels=1),
+            [],
+        ),
+    }
+
+    request = RecordingRequest(name="Silent Channel", captures=captures, mix_down=False)
+    transcription = PathTrackingTranscriptionService()
+
+    outcome = orchestrator.record(
+        request,
+        duration=0.05,
+        transcription=transcription,
+    )
+
+    metrics = outcome.channel_metrics
+    assert metrics["microphone"].frames > 0
+    assert metrics["system"].frames == 0
+    assert metrics["system"].is_silent
+    assert transcription.paths == [outcome.session.audio_paths["microphone"]]
+
+
+def test_orchestrator_skips_silent_sources_in_mix(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "adsum.db"
+    store = SessionStore(db_path)
+    orchestrator = RecordingOrchestrator(base_dir=tmp_path / "recordings", store=store)
+
+    sample_rate = 16000
+    chunk = np.zeros((sample_rate // 10, 1), dtype=np.float32)
+    captures = {
+        "microphone": FakeCapture(
+            CaptureInfo(name="microphone", sample_rate=sample_rate, channels=1),
+            [chunk],
+        ),
+        "system": FakeCapture(
+            CaptureInfo(name="system", sample_rate=sample_rate, channels=1),
+            [],
+        ),
+    }
+
+    recorded_sources: list[list[Path]] = []
+    original_mix = orchestrator_module.mix_audio_files
+
+    def _tracking_mix(paths, output_path):
+        materialised = list(paths)
+        recorded_sources.append(materialised)
+        return original_mix(materialised, output_path)
+
+    monkeypatch.setattr(orchestrator_module, "mix_audio_files", _tracking_mix)
+
+    outcome = orchestrator.record(
+        RecordingRequest(name="Mix Silent", captures=captures),
+        duration=0.05,
+        transcription=DummyTranscriptionService(),
+    )
+
+    assert recorded_sources, "mix_audio_files should be invoked"
+    assert len(recorded_sources[0]) == 1
+    assert recorded_sources[0][0].name == "microphone.wav"
+    assert outcome.session.mix_path is not None
+    assert outcome.channel_metrics["system"].is_silent
 
 
 def test_orchestrator_emits_transcript_updates(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- track per-channel capture metrics and skip silent recordings when mixing or transcribing
- raise UI warnings in both the desktop and console interfaces when a selected device records no audio
- cover the new behaviour with orchestrator regression tests for silent channels and filtered mix sources

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d2b9a00ae48329bc983b4d9c28752f