### PR TITLE
Handle oversized OpenAI transcription uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ Environment variables customise behaviour via `pydantic` settings (prefix `ADSUM
 - `ADSUM_OPENAI_TRANSCRIPTION_MODEL`: Model used for OpenAI transcription.
 - `ADSUM_OPENAI_NOTES_MODEL`: Model used for OpenAI notes/summarisation.
 - `ADSUM_OPENAI_API_KEY`: Optional API key forwarded to the OpenAI client (falls back to `OPENAI_API_KEY`).
+- `ADSUM_OPENAI_MAX_UPLOAD_BYTES`: Maximum payload size (default ~24 MiB) before recordings are automatically split for OpenAI uploads.
+
+Recordings that exceed the upload limit are transparently chunked into sequential WAV files before contacting OpenAI, ensuring long meetings are transcribed without manual intervention.
 
 ### Choosing a transcription backend
 

--- a/adsum/config.py
+++ b/adsum/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     openai_transcription_model: str = "gpt-4o-mini-transcribe"
     openai_notes_model: str = "gpt-4o-mini"
     openai_api_key: Optional[str] = None
+    openai_max_upload_bytes: int = 24 * 1024 * 1024
     session_prefix: str = "session"
     default_mic_device: Optional[str] = None
     default_system_device: Optional[str] = None

--- a/tests/test_openai_transcription_service.py
+++ b/tests/test_openai_transcription_service.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
-from adsum.data.models import RecordingSession
+from adsum.data.models import RecordingSession, TranscriptResult
 from adsum.services.transcription.openai_client import OpenAITranscriptionService
+from adsum.utils.audio import AudioChunk
 
 
 class DummyResponseFormatError(Exception):
@@ -14,6 +16,7 @@ def _make_service() -> tuple[OpenAITranscriptionService, list[str]]:
     service = object.__new__(OpenAITranscriptionService)
     service.model = "test-model"
     service._openai_error_cls = DummyResponseFormatError
+    service.max_upload_bytes = 1024 * 1024 * 1024
 
     calls: list[str] = []
 
@@ -55,3 +58,112 @@ def test_transcribe_falls_back_to_text(tmp_path):
     assert result.text == "Mock transcript from text response"
     assert result.segments == []
     assert result.raw_response == {"text": "Mock transcript from text response"}
+
+
+def test_transcribe_large_file_chunking(monkeypatch, tmp_path):
+    service, _ = _make_service()
+
+    calls: list[tuple[str, str, str]] = []
+
+    class DummyTranscriptions:
+        def create(self, model, file, response_format):
+            calls.append((model, Path(file.name).name, response_format))
+            return {
+                "text": f"chunk-{len(calls)}",
+                "segments": [
+                    {"start": 0.0, "end": 0.5, "text": f"segment-{len(calls)}"},
+                ],
+            }
+
+    service.client.audio.transcriptions = DummyTranscriptions()
+    service.max_upload_bytes = 10
+
+    chunk1 = tmp_path / "chunk1.wav"
+    chunk2 = tmp_path / "chunk2.wav"
+    chunk1.write_bytes(b"audio-1")
+    chunk2.write_bytes(b"audio-2")
+
+    chunks = [
+        AudioChunk(path=chunk1, start=0.0, duration=1.0),
+        AudioChunk(path=chunk2, start=1.0, duration=1.0),
+    ]
+
+    def fake_split(path, max_bytes):  # noqa: ARG001
+        return chunks.copy()
+
+    monkeypatch.setattr("adsum.services.transcription.openai_client.split_wave_file", fake_split)
+
+    audio_path = tmp_path / "recording.wav"
+    audio_path.write_bytes(b"large-audio")
+
+    session = RecordingSession(
+        id="session-id",
+        name="Example",
+        created_at=0,
+        duration=0,
+        sample_rate=16000,
+        channels=1,
+        audio_paths={"example": audio_path},
+    )
+
+    result = service.transcribe(session, audio_path)
+
+    assert [call[1] for call in calls] == ["chunk1.wav", "chunk2.wav"]
+    assert result.text == "chunk-1\nchunk-2"
+    assert [segment.text for segment in result.segments] == ["segment-1", "segment-2"]
+    assert result.segments[0].start == 0.0
+    assert result.segments[1].start == 1.0
+    assert not chunk1.exists()
+    assert not chunk2.exists()
+
+
+def test_transcribe_stream_chunking(monkeypatch, tmp_path):
+    service, _ = _make_service()
+    updates: list[TranscriptResult] = []
+
+    class DummyTranscriptions:
+        def create(self, model, file, response_format):
+            return {
+                "text": f"chunk-{len(updates) + 1}",
+                "segments": [
+                    {"start": 0.0, "end": 0.5, "text": f"segment-{len(updates) + 1}"},
+                ],
+            }
+
+    service.client.audio.transcriptions = DummyTranscriptions()
+    service.max_upload_bytes = 10
+
+    chunk = tmp_path / "chunk.wav"
+    chunk.write_bytes(b"audio")
+
+    chunks = [
+        AudioChunk(path=chunk, start=0.0, duration=1.0),
+    ]
+
+    def fake_split(path, max_bytes):  # noqa: ARG001
+        return chunks.copy()
+
+    monkeypatch.setattr("adsum.services.transcription.openai_client.split_wave_file", fake_split)
+
+    audio_path = tmp_path / "recording.wav"
+    audio_path.write_bytes(b"large-audio")
+
+    session = RecordingSession(
+        id="session-id",
+        name="Example",
+        created_at=0,
+        duration=0,
+        sample_rate=16000,
+        channels=1,
+        audio_paths={"example": audio_path},
+    )
+
+    def on_update(result: TranscriptResult) -> None:
+        updates.append(result)
+
+    final = service.transcribe_stream(session, audio_path, on_update=on_update)
+
+    assert updates
+    assert final.text == "chunk-1"
+    assert final.segments[0].start == 0.0
+    assert not chunk.exists()


### PR DESCRIPTION
## Summary
- add a configurable OpenAI upload size limit and document the new setting
- split large WAV recordings into timestamped chunks and merge transcription responses
- extend the OpenAI transcription tests to cover chunked batch and streaming flows

## Testing
- PYTHONPATH=. pytest tests/test_openai_transcription_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d65c7cda488329a2d3bb0fe1a6e654